### PR TITLE
Switch to api.openstreetmap.org API host

### DIFF
--- a/osmcache.py
+++ b/osmcache.py
@@ -28,7 +28,7 @@ class OsmCache:
         }
     }
     """
-    OSM_API_URL = 'https://www.openstreetmap.org/api/0.6'
+    OSM_API_URL = 'https://api.openstreetmap.org/api/0.6'
     OSM_USER_AGENT = 'aed_backup/1.0 (github.com/openstreetmap-polska)'
     CACHE_TIMEOUT = 3
     CACHE_RETRIES = 3


### PR DESCRIPTION
Use `api.openstreetmap.org/api/` -and HTTPS- instead of `www.openstreetmap.org/api/*`.

(Is: https://github.com/openstreetmap/operations/issues/951)